### PR TITLE
[mumble-web] fix startup for mumble web

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,7 +65,7 @@ mumble_web_path: /usr/lib/node_modules/mumble-web/
 # to define use yaml multiline string
 mumble_web_config: ""
 # mumble_web_supplementary_groups:
-#   - letsencrypt
+#   - mumble-server
 
 mumble_web_listen: "443"
 mumble_web_ssl_activated: True

--- a/tasks/mumble.yml
+++ b/tasks/mumble.yml
@@ -22,9 +22,9 @@
 - name: ensure mumble owns key
   file:
     path: "{{ murmur_sslkey }}"
-    owner: mumble-server
+    owner: root
     group: mumble-server
-    mode: 0600
+    mode: 0644
   notify: restart murmur
 
 - name: always start service

--- a/tasks/mumble.yml
+++ b/tasks/mumble.yml
@@ -24,7 +24,7 @@
     path: "{{ murmur_sslkey }}"
     owner: root
     group: mumble-server
-    mode: 0644
+    mode: 0640
   notify: restart murmur
 
 - name: always start service


### PR DESCRIPTION
mumble-web wasn't able to read the letsencrypt cert files. The systemd unit didn't fail and the process was running and listening on port 443, but it wasn't serving the web frontent. In the logs it was complaining:

> mumble-web[332]: handler exception: [Errno 13] Permission denied

This pull request sets working permissions and imho more appropriate ownership of the LE file. 